### PR TITLE
Edit scripts and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Django-bash
-This is a bash script for setting up django.
-For Windows, change the virtual environment from `/venv/bin/activate` to `venv/scripts/activate`
+This is a Bash script for setting up Django. Prefarably use a shortlink and curl to call the file. :)
 
-Prefarably use a shortlink and curl to call the file. :)
+Bitly shortlink is https://bit.ly/3zctaUI. Run `curl -L https://bit.ly/3zctaUI > s.sh` then `source s.sh`
 
-Bitly shortlink is https://bit.ly/3zctaUI 
-Run `curl -L https://bit.ly/3zctaUI > s.sh` then `source s.sh`
+### Running on Windows
+Change the virtual environment from `/venv/bin/activate` to `venv/scripts/activate`
 
 ### Running it on MacOS
-Mac OS X uses the BSD version of sed, which treats the -i option slightly differently.
-Use gsed instead, install with `brew install gnu-sed`
+Mac OS X uses the BSD version of sed, which treats the -i option slightly differently. Instead, use [gsed](https://formulae.brew.sh/formula/gnu-sed) instead, install with `brew install gnu-sed`
 then run `curl -L https://bit.ly/3n1AWJQ > a.sh` then `source a.sh`

--- a/a.sh
+++ b/a.sh
@@ -12,16 +12,20 @@ blue=`tput setaf 4`
 magenta=`tput setaf 5`
 cyan=`tput setaf 6`
 reset= `tput sgr0`
+
 curl https://raw.githubusercontent.com/github/gitignore/main/Python.gitignore > .gitignore
-pip install django
+
+pip install django===3.2.13
+
+#Django project setup
 echo "${green}Installing Django${reset}"
-echo "${blue}Enter a Project name${reset}"
-read project_name
+read -p "${blue}Enter a Project name${reset}: " project_name
 echo "${cyan}Creating Django project${reset}"
 django-admin startproject $project_name .
 echo "Project created"
-echo "${green}Creating a new Django app,Enter an app name${reset}"
-read app_name
+
+#Django app creation
+read -p "${green}Enter an App name${reset}: " app_name
 python manage.py startapp $app_name
 echo "${magenta}Creating a new Django app${reset}"
 
@@ -42,6 +46,7 @@ echo "from django.shortcuts import render" >> $app_name/views.py
 echo "def index(request):" >> $app_name/views.py
 echo "    return render(request, 'index.html')" >> $app_name/views.py
 echo "${green}View created${reset}"
+
 #add app to urls.py
 echo "${green}Adding app to urls.py......${reset}"
 touch $app_name/urls.py

--- a/s.sh
+++ b/s.sh
@@ -12,16 +12,19 @@ blue=`tput setaf 4`
 magenta=`tput setaf 5`
 cyan=`tput setaf 6`
 reset= `tput sgr0`
+
 curl https://raw.githubusercontent.com/github/gitignore/main/Python.gitignore > .gitignore
+
+#Django project setup
 pip install django
 echo "${green}Installing Django${reset}"
-echo "${blue}Enter a Project name${reset}"
-read project_name
+read -p "${blue}Enter a Project name${reset}: " project_name
 echo "${cyan}Creating Django project${reset}"
 django-admin startproject $project_name .
 echo "Project created"
-echo "${green}Creating a new Django app,Enter an app name${reset}"
-read app_name
+
+#Django app creation
+read -p "${green}Enter an app name${reset}: " app_name
 python manage.py startapp $app_name
 echo "${magenta}Creating a new Django app${reset}"
 
@@ -42,6 +45,7 @@ echo "from django.shortcuts import render" >> $app_name/views.py
 echo "def index(request):" >> $app_name/views.py
 echo "    return render(request, 'index.html')" >> $app_name/views.py
 echo "${green}View created${reset}"
+
 #add app to urls.py
 echo "${green}Adding app to urls.py......${reset}"
 touch $app_name/urls.py


### PR DESCRIPTION
I noticed that the prompts could be done on just one line as opposed to two using the `-p` prompt flag for the `read` command.

I also revised the `README.md` file to include headers with instructions for working with the Windows and macOS operating systems. Also included a link to the `gnu-sed` Homebrew package.